### PR TITLE
fix alarm timing, frequency updates, and minor bugs; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,84 @@
-# Read more about Stretch at http://guanzgrace.github.io/stretch
+# Stretch Reminder
 
-#### What is Stretch?
-- Stretch is a Google Chrome extension that reminds users to stretch every 30, 60, or 120 minutes with office-friendly exercises taken from the Physera API. Options allow the user to enable/disable the application, set the frequency of reminders, and change what area of the body the exercises target.
+> **Note:** This project is no longer actively maintained and has been removed from the Chrome Web Store. It was originally published as a Chrome extension from 2016–2024 with 1000+ daily active users. The source code is preserved here for reference. You can still run it locally by loading it as an unpacked extension.
 
-#### Stretch Progress
-- Working Version 1 (Beta Testing Version): notification page, storage for exercise.json, fix schedule for notifications, update aesthetics, options page, alarms reset, toggle on/off button, making sure that options fully work, need to test options from 9-5 and make sure they turn off post 5 pm, alarms reset
-- Working Version 2 (Mainfest Version 0.1.0): removed options page, frequency button, make window active when using chrome.tab.updates, bootstrapped, different types of exercises, ensure popup.html closes, create a fixed size for notification.html
-- Working Version 3 (Manifest Version 0.2.1 and 0.2.2): design overhaul
-- Working Version 4 (Manifest Version 0.3.0): fix API bugs, push back to chrome store
-- Working Version 5 (Manifest Version 0.4.0): fix API bugs, add link to doc page in popup menu, push back to chrome store
-- Working Version 6 (Manifest Version 0.5.0): modernize app
-    - Migrated to Manifest V3 (service worker, action API)
-    - Removed jQuery and Bootstrap JS dependencies
-    - Localized exercise data (no longer fetches from external API)
-    - Optimized tab tracking with chrome.storage.session
-    - Switched event handlers to addEventListener
-    - Centralized notification logic in background service worker
+A Chrome extension that reminded users to stretch every 30, 60, or 120 minutes with office-friendly exercises. Built to help people take care of their bodies during long work sessions.
 
-#### Stretch Links
-- More Info: http://guanzgrace.github.io/stretch
+<p align="center">
+  <img src="logo/Logo_physera_128.png" alt="Stretch Reminder logo" width="100">
+</p>
+
+## Features
+
+- **Timed reminders** — stretch notifications every 30 minutes, 1 hour, or 2 hours
+- **Targeted exercises** — upper body, lower body, or full body stretches
+- **One-click toggle** — enable or disable reminders from the popup
+- **Popup window** — exercises open in a dedicated window so they don't disrupt your tabs
+- **Offline-ready** — all exercise data is bundled locally, no external API calls
+
+## Screenshots
+
+| Popup | Exercise Notification |
+|-------|----------------------|
+| ![Popup](logo/Screenshot-1.png) | ![Notification](logo/Screenshot-2.png) |
+
+## Running Locally
+
+If you'd like to try it out, you can load the extension from source:
+
+1. Clone or download this repository
+2. Open `chrome://extensions` in Chrome
+3. Enable **Developer mode** (toggle in the top right)
+4. Click **Load unpacked** and select the repository folder
+5. The Stretch Reminder icon will appear in your toolbar
+
+## Usage
+
+Click the extension icon in your Chrome toolbar to open the popup, where you can:
+
+- **Get an exercise now** — open a stretch exercise immediately
+- **Change exercise type** — cycle through Upper Body, Lower Body, and Full Body
+- **Change frequency** — cycle through Every 30 Minutes, Every 1 Hour, and Every 2 Hours
+- **Enable / disable** — toggle the reminder on or off
+
+When a reminder fires, a popup window opens with a random exercise, including the name, rep count, step-by-step instructions, and an illustration.
+
+## Project Structure
+
+```
+├── manifest.json          # Extension manifest (Manifest V3)
+├── popup.html             # Toolbar popup UI
+├── notification.html      # Exercise notification page
+├── js/
+│   ├── background.js      # Service worker — alarm & notification logic
+│   ├── popup.js           # Popup controls & settings
+│   ├── notification.js    # Exercise selection & display
+│   └── fontawesome.js     # Icon font
+├── css/
+│   ├── popup.css          # Popup styles
+│   ├── notification.css   # Notification styles
+│   └── bootstrap.min.css  # Bootstrap (notification layout)
+├── exercises/             # Bundled exercise data (JSON)
+├── logo/                  # Icons & screenshots
+└── docs/                  # GitHub Pages site
+```
+
+## Version History
+
+| Version | Highlights |
+|---------|------------|
+| 0.5.1 | Fixed alarm firing on Chrome restart; fixed alarm timing not respecting frequency setting; minor bug fixes |
+| 0.5.0 | Migrated to Manifest V3, removed jQuery/Bootstrap JS, localized exercise data, optimized tab tracking |
+| 0.4.0 | API bug fixes, added About link in popup |
+| 0.3.0 | API bug fixes, re-published to Chrome Web Store |
+| 0.2.x | Design overhaul |
+| 0.1.0 | First published version — frequency selector, exercise types, bootstrap styling |
+
+## Links
+
+- [Project homepage](https://guanzgrace.github.io/stretch/)
+- Exercise data sourced from [Physera](https://physera.com/)
+
+## License
+
+This project is open source. Exercise data and illustrations are property of Physera.

--- a/js/background.js
+++ b/js/background.js
@@ -1,57 +1,76 @@
-// upon launching, create the alarm
-recreateAlarm();
+// Stretch Reminder - Background Service Worker
 
-// opens the notifications tab every 30m/1h/2h at xx:30 and xx:00. xx is odd for every 2h.
-// clears the past alarmStart and creates a new one.
-function createAlarm(freq) {
-    const now = new Date();
-    const day = now.getDate();
-    const timestamp = +new Date(now.getFullYear(), now.getMonth(), day, 1, 0, 0, 0);
-
-    chrome.alarms.clearAll();
-    chrome.alarms.create('alarmStart', {
-        when: timestamp, periodInMinutes: freq
-    });
-}
-
-// opens the notification in a new browser tab.
-async function openNotification() {
-    const { notificationTabId } = await chrome.storage.session.get('notificationTabId');
-    if (notificationTabId) {
-        await chrome.tabs.remove(notificationTabId).catch(() => {});
-    }
-    const win = await chrome.windows.create({ url: 'notification.html', type: "popup",
-                                              width: 1150, height: 720, top: 20, left: 20 });
-    await chrome.storage.session.set({ notificationTabId: win.tabs[0].id });
-}
-
-// recreates the alarm either by default or by storage, if they exist
-function recreateAlarm() {
-    chrome.storage.local.get('freq', function(options) {
-        if (options.freq != null) { createAlarm(parseInt(options.freq)); }
-        else { createAlarm(30); }
-    });
-}
-
-// listen for messages from popup
-chrome.runtime.onMessage.addListener(function(message) {
-    if (message.action === 'openNotification') {
-        openNotification();
+// When the service worker starts (browser launch, wake from idle, extension install/update),
+// ensure an alarm exists — but don't create a duplicate if one is already running.
+chrome.alarms.get('alarmStart', (existingAlarm) => {
+    if (!existingAlarm) {
+        recreateAlarm();
     }
 });
 
-// listen for time and open the notification if it meets correct conditions
+// Creates (or recreates) the stretch reminder alarm.
+// Uses delayInMinutes so the first fire happens after one full interval,
+// not immediately (which was the old bug — a past `when` timestamp fired instantly).
+function createAlarm(freq) {
+    chrome.alarms.clearAll(() => {
+        chrome.alarms.create('alarmStart', {
+            delayInMinutes: freq,
+            periodInMinutes: freq
+        });
+    });
+}
+
+// Opens the notification in a popup window, closing any previously opened one.
+async function openNotification() {
+    try {
+        const { notificationTabId } = await chrome.storage.session.get('notificationTabId');
+        if (notificationTabId) {
+            await chrome.tabs.remove(notificationTabId).catch(() => {});
+        }
+        const win = await chrome.windows.create({
+            url: 'notification.html',
+            type: 'popup',
+            width: 1150,
+            height: 720,
+            top: 20,
+            left: 20
+        });
+        await chrome.storage.session.set({ notificationTabId: win.tabs[0].id });
+    } catch (e) {
+        console.error('Failed to open notification:', e);
+    }
+}
+
+// Reads the saved frequency from storage and creates an alarm with it (default: 30 min).
+function recreateAlarm() {
+    chrome.storage.local.get('freq', function(options) {
+        const freq = options.freq != null ? parseInt(options.freq) : 30;
+        createAlarm(freq);
+    });
+}
+
+// Listen for messages from popup (open notification, or recreate alarm on setting change).
+chrome.runtime.onMessage.addListener(function(message) {
+    if (message.action === 'openNotification') {
+        openNotification();
+    } else if (message.action === 'recreateAlarm') {
+        recreateAlarm();
+    }
+});
+
+// When the alarm fires, open a notification if reminders are enabled.
 chrome.alarms.onAlarm.addListener(function(alarm) {
+    if (alarm.name !== 'alarmStart') return;
+
     chrome.storage.local.get('enabled', function(option) {
-        if (option.enabled != null) {
-            if (alarm.name === 'alarmStart' && option.enabled) {
-                openNotification();
-            }
-        } else { // option.enabled == null, first initialization
-            openNotification();
-            chrome.storage.local.set({'enabled': true}, function() {
-              console.log("Enabled set to true.");
-            });
+        if (option.enabled === false) {
+            // User explicitly disabled — do nothing.
+            return;
+        }
+        // enabled === true or null (first run) — show the notification.
+        openNotification();
+        if (option.enabled == null) {
+            chrome.storage.local.set({ 'enabled': true });
         }
     });
 });

--- a/js/notification.js
+++ b/js/notification.js
@@ -41,12 +41,12 @@ function displayExercise(selectedExercise) {
 
     var rc = selectedExercise.reps;
     var rt = selectedExercise.rep_time;
-    if (rc != null & rt != null) {
+    if (rc != null && rt != null) {
         var repetitions = document.createElement('p');
         var repString = "<i class=\"fa fa-clock-o\" aria-hidden=\"true\"></i> ";
         repString += rc;
         if (rc > 1) { repString += " repetitions, one every " + rt + " seconds."; }
-        else if (rc = 1) { repString += " repetition for " + rt + " seconds."; }
+        else if (rc == 1) { repString += " repetition for " + rt + " seconds."; }
         repetitions.innerHTML = repString;
         document.getElementById('content').append(repetitions);
     }

--- a/js/popup.js
+++ b/js/popup.js
@@ -48,17 +48,20 @@ document.getElementById("frequency").addEventListener('click', function(){
 	if(document.getElementById("frequency").firstChild.data == "Every 2 Hours") {
 		chrome.storage.local.set({'freq': 30}, function() {
 	      console.log("Set frequency to every 30 minutes.");
+	      chrome.runtime.sendMessage({ action: 'recreateAlarm' });
 	    });
 		document.getElementById("frequency").firstChild.data = "Every 30 Minutes";
 	} // currently says 30 min, set to be every hour
 	else if(document.getElementById("frequency").firstChild.data == "Every 30 Minutes")  {
 		chrome.storage.local.set({'freq': 60}, function() {
 	      console.log("Set frequency to every 60 minutes.");
+	      chrome.runtime.sendMessage({ action: 'recreateAlarm' });
 	    });
 		document.getElementById("frequency").firstChild.data = "Every 1 Hour";
 	} else { // currently says 1 hour, set to every 2 hours
 		chrome.storage.local.set({'freq': 120}, function() {
 	      console.log("Set frequency to every 120 minutes.");
+	      chrome.runtime.sendMessage({ action: 'recreateAlarm' });
 	    });
 		document.getElementById("frequency").firstChild.data = "Every 2 Hours";
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Stretch Reminder",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Reminds you to stretch every 30, 60, or 120 minutes with office-friendly, full body stretches.",
   "icons": {
     "16": "logo/Logo_physera_16.png",
@@ -13,7 +13,7 @@
   },
   "homepage_url": "https://guanzgrace.github.io/stretch/",
   "short_name": "Stretch",
-  "permissions": ["tabs", "storage", "alarms"],
+  "permissions": ["storage", "alarms"],
   "action": {
     "default_title": "Stretch Reminder",
     "default_popup": "popup.html"


### PR DESCRIPTION
- Prevent duplicate alarms on service worker restart
- Use delayInMinutes instead of past `when` timestamp
- Recreate alarm when frequency is changed in popup
- Fix bitwise AND (`&`) to logical AND (`&&`) in notification.js
- Fix assignment (`=`) to comparison (`==`) in notification.js
- Remove unnecessary `tabs` permission
- Rewrite README with updated docs and version history

Closes #10
Closes #11